### PR TITLE
Mungkin sebuah Bug atau hanya kelupaan

### DIFF
--- a/donjo-app/helpers/pict_helper.php
+++ b/donjo-app/helpers/pict_helper.php
@@ -487,7 +487,7 @@ function UploadSimbol($fupload_name){
   move_uploaded_file($_FILES["simbol"]["tmp_name"], $vfile_upload);
 }
 
-define (MIME_TYPE_DOKUMEN, serialize (array(
+define ('MIME_TYPE_DOKUMEN', serialize (array(
   "application/x-download",
   "application/pdf",
   "application/zip",

--- a/donjo-app/models/penduduk_model.php
+++ b/donjo-app/models/penduduk_model.php
@@ -309,7 +309,7 @@
 		$sql = $select_sql."
 		FROM tweb_penduduk u
 		LEFT JOIN tweb_keluarga d ON u.id_kk = d.id
-		LEFT JOIN tweb_wil_clusterdesa a ON d.id_cluster = a.id
+		LEFT JOIN tweb_wil_clusterdesa a ON d.id = a.id
 		LEFT JOIN tweb_penduduk_pendidikan_kk n ON u.pendidikan_kk_id = n.id
 		LEFT JOIN tweb_penduduk_pendidikan sd ON u.pendidikan_sedang_id = sd.id
 		LEFT JOIN tweb_penduduk_pekerjaan p ON u.pekerjaan_id = p.id


### PR DESCRIPTION
Pertama install ada error Query jika masuk di bagian penduduk 

`LEFT JOIN tweb_wil_clusterdesa a ON d.id_cluster = a.id` 

seharusnya

`LEFT JOIN tweb_wil_clusterdesa a ON d.id = a.id`

karena di tabel `tweb_wil_clusterdesa` tidak ada `id_cluster`

kemudian  dibagian `pic_helper.php` ada error pada bagian 

`define (MIME_TYPE_DOKUMEN, serialize (array(...` dibeberapa versi php tanpa singel quote tetap berjalan, tetapai di beberapa lagi tidak, apaa tidak seharunya menggunakan singel quote seperti 

`define ('MIME_TYPE_DOKUMEN', serialize (array(....`