### PR TITLE
Fix Common::get_config() error in PHP 5.6

### DIFF
--- a/donjo-sys/core/Common.php
+++ b/donjo-sys/core/Common.php
@@ -254,7 +254,8 @@ if ( ! function_exists('get_config'))
 			}
 		}
 
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
In PHP assignment expressions always return the assigned value. So `$_config[0] =& $config` returns `$config` - but not the variable itself, but a copy of its value. And returning a reference to a temporary value wouldn't be particularly useful (changing it wouldn't do anything).
[Referensi](https://stackoverflow.com/questions/28348879/only-variable-references-should-be-returned-by-reference-codeigniter)